### PR TITLE
Writing labels into scores with ms3 1.2.0

### DIFF
--- a/annotate.py
+++ b/annotate.py
@@ -203,7 +203,8 @@ def annotate(
             )
 
             if piece.name is not None and output_tsv_dir is not None:
-                piece_name = Path(piece.name).stem
+                # Removes the ID and first space from piece.name, and stems remaining path
+                piece_name = Path(" ".join(piece.name.split(" ")[1:])).stem
                 output_tsv_path = output_tsv_dir / (piece_name + ".tsv")
 
                 try:

--- a/annotate.py
+++ b/annotate.py
@@ -203,8 +203,8 @@ def annotate(
             )
 
             if piece.name is not None and output_tsv_dir is not None:
-                piece_name = Path(piece.name.split(" ")[-1])
-                output_tsv_path = output_tsv_dir / (piece_name.stem + ".tsv")
+                piece_name = Path(piece.name).stem
+                output_tsv_path = output_tsv_dir / (piece_name + ".tsv")
 
                 try:
                     output_tsv_path.parent.mkdir(parents=True, exist_ok=True)

--- a/harmonic_inference/utils/eval_utils.py
+++ b/harmonic_inference/utils/eval_utils.py
@@ -1,6 +1,5 @@
 """Utility functions for evaluating model outputs."""
 import logging
-import re
 from collections import defaultdict
 from fractions import Fraction
 from pathlib import Path
@@ -8,7 +7,6 @@ from typing import Dict, List, Tuple, Union
 
 import numpy as np
 import pandas as pd
-from ms3 import Parse
 
 import harmonic_inference.utils.harmonic_constants as hc
 import harmonic_inference.utils.harmonic_utils as hu
@@ -1358,45 +1356,6 @@ def get_results_annotation_df(
     post_process_labels(labels_list, label_type, global_tonic, global_mode, tonic_type)
 
     return pd.DataFrame(labels_list)
-
-
-def write_labels_to_score(
-    labels_dir: Union[str, Path],
-    annotations_dir: Union[str, Path],
-    basename: str,
-):
-    """
-    Write the annotation labels from a given directory onto a musescore file.
-
-    Parameters
-    ----------
-    labels_dir : Union[str, Path]
-        The directory containing the tsv file containing the model's annotations.
-    annotations_dir : Union[str, Path]
-        The directory containing the ground truth annotations and MS3 score file.
-    basename : str
-        The basename of the annotation TSV and the ground truth annotations/MS3 file.
-    """
-    if isinstance(labels_dir, Path):
-        labels_dir = str(labels_dir)
-
-    if isinstance(annotations_dir, Path):
-        annotations_dir = str(annotations_dir)
-
-    # Add musescore and tsv suffixes to filename match
-    filename_regex = re.compile(basename + "\\.(mscx|tsv)")
-
-    # Parse scores and tsvs
-    parse = Parse(annotations_dir, file_re=filename_regex)
-    parse.add_dir(labels_dir, key="labels", file_re=filename_regex)
-    parse.parse()
-
-    # Write annotations to score
-    parse.add_detached_annotations("MS3", "labels")
-    parse.attach_labels(staff=-1, voice=1, check_for_clashes=False, label_type=1)
-
-    # Write score out to file
-    parse.store_mscx(root_dir=labels_dir, suffix="_inferred", overwrite=True)
 
 
 def average_results(results_path: Union[Path, str], split_on: str = " = ") -> Dict[str, float]:

--- a/harmonic_inference/utils/forces.py
+++ b/harmonic_inference/utils/forces.py
@@ -223,7 +223,7 @@ def extract_forces_from_musescore(
         return tonic, mode, id_type
 
     score = Score(score_path)
-    labels: pd.DataFrame = score.annotations.get_labels(decode=True)
+    labels: pd.DataFrame = score.mscx.labels()
 
     chord_changes = set()
     chord_non_changes = set()

--- a/setup.cfg
+++ b/setup.cfg
@@ -25,7 +25,7 @@ packages =
 install_requires =
     h5py
     matplotlib
-    ms3>=1.2.0
+    ms3>=1.2.1
     music21
     numpy
     pandas

--- a/setup.cfg
+++ b/setup.cfg
@@ -25,7 +25,7 @@ packages =
 install_requires =
     h5py
     matplotlib
-    ms3
+    ms3>=1.2.0
     music21
     numpy
     pandas

--- a/test.py
+++ b/test.py
@@ -3,11 +3,11 @@ import argparse
 import logging
 import os
 import sys
-from glob import glob
 from pathlib import Path
-from typing import List, Union
+from typing import List, Literal, Optional, Union
 
 import h5py
+import ms3
 import numpy as np
 import torch
 from tqdm import tqdm
@@ -30,6 +30,13 @@ SPLITS = ["train", "valid", "test"]
 def write_tsvs_to_scores(
     output_tsv_dir: Union[Path, str],
     annotations_base_dir: Union[Path, str],
+    suffix: str = "_inferred",
+    ask_for_input: bool = True,
+    replace: bool = True,
+    staff: Optional[Literal[1, 2, 3, 4]] = None,
+    voice: Literal[1, 2, 3, 4] = None,
+    harmony_layer: Optional[Literal[0, 1, 2]] = None,
+    check_for_clashes: bool = True,
 ):
     """
     Write the labels TSVs from the given output directory onto annotated scores
@@ -42,24 +49,87 @@ def write_tsvs_to_scores(
         The directory should contain sub-directories for each composer (aligned
         with sub-dirs in the annotations base directory), and a single TSV for each
         output.
+
     annotations_base_dir : Union[Path, str]
         The path to annotations and MuseScore3 scores, whose sub-directories and file names
         are aligned with those in the output TSV directory.
+
+    suffix : str
+        Suffix to be added to the newly created scores. Defaults to _inferred.
+
+    ask_for_input : bool
+        What to do if more than one TSV or MuseScore file is detected for a particular fname.
+        By default, the user is asked for input.
+        Pass False to prevent that and pick the files with the shortest relative paths instead.
+
+    replace : bool
+        By default, any existing labels are removed from the scores. Pass False to leave them in,
+        which may lead to clashes.
+
+    staff : Optional[int]
+        If you pass a staff ID, the labels will be attached to that staff where 1 is the upper
+        staff.
+        By default, the staves indicated in the 'staff' column of the labels are used, or, if
+        such a column is not present, labels will be inserted under the lowest staff -1.
+
+    voice : Optional[Literal[1, 2, 3, 4]]
+        If you pass the ID of a notational layer (where 1 is the upper voice, blue in MuseScore),
+        the labels will be attached to that one.
+        By default, the notational layers indicated in the 'voice' column of the labels are used,
+        or, if such a column is not present, labels will be inserted for voice 1.
+
+    harmony_layer : Optional[Literal[0, 1, 2]]
+        | By default, the labels are written to the layer specified as an integer in the
+          'harmony_layer' of the label. Pass an integer to select a particular layer:
+        | * 0 to attach them as absolute ('guitar') chords, meaning that when opened next time,
+        |   MuseScore will split and encode those beginning with a note name
+        |   (resulting in ms3-internal harmony_layer 3).
+        | * 1 the labels are written into the staff's layer for Roman Numeral Analysis.
+        | * 2 to have MuseScore interpret them as Nashville Numbers
+
+    check_for_clashes : bool
+        By default, warnings are thrown when there already exists a label at a position
+        (and in a notational layer) where a new one is attached. Pass False to deactivate these
+        warnings.
+
+
     """
     output_tsv_dir = Path(output_tsv_dir)
     annotations_base_dir = Path(annotations_base_dir)
-
-    output_paths = sorted(glob(str(output_tsv_dir / "**" / "*.tsv"), recursive=True))
-    for piece_name in tqdm(output_paths, desc="Writing labesl to scores"):
-        piece_name = Path(piece_name).relative_to(output_tsv_dir)
-        try:
-            eu.write_labels_to_score(
-                output_tsv_dir / piece_name.parent,
-                annotations_base_dir / piece_name.parent,
-                piece_name.stem,
-            )
-        except Exception:
-            logging.exception("Error writing score out to %s", output_tsv_dir / piece_name.parent)
+    outputs_are_under_corpus_path = (output_tsv_dir == annotations_base_dir) or (
+        annotations_base_dir in annotations_base_dir.parents
+    )
+    corpus = ms3.Corpus(annotations_base_dir, only_metadata_fnames=False)
+    if not outputs_are_under_corpus_path:
+        # if the Corpus directory itself includes any labels we exclude them to avoid ambiguity
+        if any(x.is_dir() and x.name == "labels" for x in annotations_base_dir.iterdir()):
+            excluded_labels_path = annotations_base_dir / "labels"
+            corpus.view.exclude("path", str(excluded_labels_path))
+    _ = corpus.add_dir(
+        output_tsv_dir,
+        filter_other_fnames=True,
+        file_re=r"\.tsv$",
+        exclude_re="",
+    )
+    ms3.insert_labels_into_score(
+        corpus,
+        facet="labels",
+        ask_for_input=ask_for_input,
+        replace=replace,
+        staff=staff,
+        voice=voice,
+        harmony_layer=harmony_layer,
+        check_for_clashes=check_for_clashes,
+        print_info=False,
+    )
+    ms3.store_scores(
+        corpus,
+        only_changed=True,
+        root_dir=output_tsv_dir,
+        folder=".",
+        suffix=suffix,
+        overwrite=True,
+    )
 
 
 def evaluate(

--- a/write_to_score.py
+++ b/write_to_score.py
@@ -1,19 +1,21 @@
 """A script that can be used to write annotate.py or test.py outputs to a musical score."""
 import argparse
-import logging
-from glob import glob
 from pathlib import Path
-from typing import Union
+from typing import Literal, Optional, Union
 
-from tqdm import tqdm
-
-import harmonic_inference.utils.eval_utils as eu
+import ms3
 
 
 def write_tsvs_to_scores(
     output_tsv_dir: Union[Path, str],
     annotations_base_dir: Union[Path, str],
-    fuzzy: bool = False,
+    suffix: str = "_inferred",
+    ask_for_input: bool = True,
+    replace: bool = True,
+    staff: Optional[Literal[1, 2, 3, 4]] = None,
+    voice: Literal[1, 2, 3, 4] = None,
+    harmony_layer: Optional[Literal[0, 1, 2]] = None,
+    check_for_clashes: bool = True,
 ):
     """
     Write the labels TSVs from the given output directory onto annotated scores
@@ -31,29 +33,76 @@ def write_tsvs_to_scores(
         The path to annotations and MuseScore3 scores, whose sub-directories and file names
         are aligned with those in the output TSV directory.
 
-    fuzzy : bool
-        If True, the annotations do not need to match exactly in sub-directory structure,
-        only in file name.
+    suffix : str
+        Suffix to be added to the newly created scores. Defaults to _inferred.
+
+    ask_for_input : bool
+        What to do if more than one TSV or MuseScore file is detected for a particular fname.
+        By default, the user is asked for input.
+        Pass False to prevent that and pick the files with the shortest relative paths instead.
+
+    replace : bool
+        By default, any existing labels are removed from the scores. Pass False to leave them in,
+        which may lead to clashes.
+
+    staff : Optional[int]
+        If you pass a staff ID, the labels will be attached to that staff where 1 is the upper
+        staff.
+        By default, the staves indicated in the 'staff' column of the labels are used, or, if
+        such a column is not present, labels will be inserted under the lowest staff -1.
+
+    voice : Optional[Literal[1, 2, 3, 4]]
+        If you pass the ID of a notational layer (where 1 is the upper voice, blue in MuseScore),
+        the labels will be attached to that one.
+        By default, the notational layers indicated in the 'voice' column of the labels are used,
+        or, if such a column is not present, labels will be inserted for voice 1.
+
+    harmony_layer : Optional[Literal[0, 1, 2]]
+        | By default, the labels are written to the layer specified as an integer in the
+          'harmony_layer' of the label. Pass an integer to select a particular layer:
+        | * 0 to attach them as absolute ('guitar') chords, meaning that when opened next time,
+        |   MuseScore will split and encode those beginning with a note name
+        |   (resulting in ms3-internal harmony_layer 3).
+        | * 1 the labels are written into the staff's layer for Roman Numeral Analysis.
+        | * 2 to have MuseScore interpret them as Nashville Numbers
+
+    check_for_clashes : bool
+        By default, warnings are thrown when there already exists a label at a position
+        (and in a notational layer) where a new one is attached. Pass False to deactivate these
+        warnings.
+
+
     """
     output_tsv_dir = Path(output_tsv_dir)
     annotations_base_dir = Path(annotations_base_dir)
-
-    output_paths = sorted(glob(str(output_tsv_dir / "**" / "*.tsv"), recursive=True))
-    output_paths = [
-        path
-        for path in output_paths
-        if not path.endswith("_results.tsv") and not path.endswith("results_midi.tsv")
-    ]
-    for piece_name in tqdm(output_paths, desc="Writing labels to scores"):
-        piece_name = Path(piece_name).relative_to(output_tsv_dir)
-        try:
-            eu.write_labels_to_score(
-                output_tsv_dir / piece_name.parent,
-                annotations_base_dir if fuzzy else annotations_base_dir / piece_name.parent,
-                piece_name.stem,
-            )
-        except Exception:
-            logging.exception("Error writing score out to %s", output_tsv_dir / piece_name.parent)
+    outputs_are_under_corpus_path = (output_tsv_dir == annotations_base_dir) or (
+        annotations_base_dir in annotations_base_dir.parents
+    )
+    corpus = ms3.Corpus(annotations_base_dir, only_metadata_fnames=False)
+    if not outputs_are_under_corpus_path:
+        # if the Corpus directory itself includes any labels we exclude them to avoid ambiguity
+        if any(x.is_dir() and x.name == "labels" for x in annotations_base_dir.iterdir()):
+            excluded_labels_path = annotations_base_dir / "labels"
+        corpus.view.exclude("path", str(excluded_labels_path))
+    corpus.add_dir(output_tsv_dir)
+    ms3.insert_labels_into_score(
+        corpus,
+        facet="labels",
+        ask_for_input=ask_for_input,
+        replace=replace,
+        staff=staff,
+        voice=voice,
+        harmony_layer=harmony_layer,
+        check_for_clashes=check_for_clashes,
+    )
+    ms3.store_scores(
+        corpus,
+        only_changed=True,
+        root_dir=output_tsv_dir,
+        folder=".",
+        suffix=suffix,
+        overwrite=True,
+    )
 
 
 if __name__ == "__main__":

--- a/write_to_score.py
+++ b/write_to_score.py
@@ -83,8 +83,13 @@ def write_tsvs_to_scores(
         # if the Corpus directory itself includes any labels we exclude them to avoid ambiguity
         if any(x.is_dir() and x.name == "labels" for x in annotations_base_dir.iterdir()):
             excluded_labels_path = annotations_base_dir / "labels"
-        corpus.view.exclude("path", str(excluded_labels_path))
-    corpus.add_dir(output_tsv_dir)
+            corpus.view.exclude("path", str(excluded_labels_path))
+    _ = corpus.add_dir(
+        output_tsv_dir,
+        filter_other_fnames=True,
+        file_re=r"\.tsv$",
+        exclude_re="",
+    )
     ms3.insert_labels_into_score(
         corpus,
         facet="labels",
@@ -94,6 +99,7 @@ def write_tsvs_to_scores(
         voice=voice,
         harmony_layer=harmony_layer,
         check_for_clashes=check_for_clashes,
+        print_info=False,
     )
     ms3.store_scores(
         corpus,

--- a/write_to_score.py
+++ b/write_to_score.py
@@ -132,16 +132,6 @@ if __name__ == "__main__":
         ),
     )
 
-    parser.add_argument(
-        "-f",
-        "--fuzzy",
-        action="store_true",
-        help=(
-            "Do not require that the annotations sub-directory structure matches the output "
-            "directory structure exactly. Rather, matches are made only by filename."
-        ),
-    )
-
     ARGS = parser.parse_args()
 
-    write_tsvs_to_scores(ARGS.output, ARGS.annotations, fuzzy=ARGS.fuzzy)
+    write_tsvs_to_scores(ARGS.output, ARGS.annotations)


### PR DESCRIPTION
Hi Andrew, 

with this suggestion, utils.eval_utils.write_labels_to_score() is not needed anymore. write_to_score.write_tsvs_to_scores() on the other hand now has various options for where and how to insert the labels. If you prefer fixing them, we can simply set them to the defaults used before. That's why I haven't integrated them in the CLI.

Was it done on purpose that previously the annotated TSV files would be named only with the last word of the original file name? Because this would not work with ms3's file matching which is entirely based on the idea of a fixed `fname` component plus arbitrary suffixes. This is why I made the little change in annotate.py, hope you're OK with that.